### PR TITLE
Fix incorrect regex parsing of WiFi SSID

### DIFF
--- a/app/src/main/java/be/casperverswijvelt/unifiedinternetqs/util/Util.kt
+++ b/app/src/main/java/be/casperverswijvelt/unifiedinternetqs/util/Util.kt
@@ -105,7 +105,7 @@ fun getConnectedWifiSSID(
             "dumpsys netstats | grep -E 'iface=wlan.*(networkId|wifiNetworkKey)'",
             context = context
         ) {
-            val pattern = "(?<=(networkId|wifiNetworkKey)=\").*(?=\")".toRegex()
+            val pattern = "(?<=(networkId|wifiNetworkKey)=\").*?(?=\")".toRegex()
             it?.out?.forEach { wifiString ->
                 pattern.find(wifiString)?.let { matchResult ->
                     callback(matchResult.value)


### PR DESCRIPTION
When the `ident` array contains multiple elements, the `.*` greedy quantifier between the capturing groups matches all text between the opening quote of the first element and the closing quote of the last element, resulting in a very long SSID parsed. Using a lazy quantifier instead stops at the first closing quote.

Fixes #59 